### PR TITLE
Big fix for false +0 (or +0.0 mmol) bg deltas

### DIFF
--- a/xDrip Watch App/DataModels/WatchStateModel.swift
+++ b/xDrip Watch App/DataModels/WatchStateModel.swift
@@ -163,13 +163,13 @@ final class WatchStateModel: NSObject, ObservableObject {
             // quickly check "value" and prevent "-0mg/dl" or "-0.0mmol/l" being displayed
             // show unitized zero deltas as +0 or +0.0 as per Nightscout format
             if (isMgDl) {
-                if (deltaChangeInMgDl > -1) && (deltaChangeInMgDl < 1) {
+                if (deltaChangeInMgDl == 0) {
                     return "+0"
                 } else {
                     return deltaSign + valueAsString
                 }
             } else {
-                if (deltaChangeInMgDl > -0.1) && (deltaChangeInMgDl < 0.1) {
+                if (deltaChangeInMgDl == 0.0) {
                     return "+0.0"
                 } else {
                     return deltaSign + valueAsString

--- a/xDrip Watch Complication/XDripWatchComplication+Entry.swift
+++ b/xDrip Watch Complication/XDripWatchComplication+Entry.swift
@@ -85,9 +85,9 @@ extension XDripWatchComplication.Entry {
                 // quickly check "value" and prevent "-0mg/dl" or "-0.0mmol/l" being displayed
                 // show unitized zero deltas as +0 or +0.0 as per Nightscout format
                 if (isMgDl) {
-                    return (deltaChangeInMgDl > -1 && deltaChangeInMgDl < 1) ?  "+0" : (deltaSign + valueAsString)
+                    return (deltaChangeInMgDl == 0) ?  "+0" : (deltaSign + valueAsString)
                 } else {
-                    return (deltaChangeInMgDl > -0.1 && deltaChangeInMgDl < 0.1) ? "+0.0" : (deltaSign + valueAsString)
+                    return (deltaChangeInMgDl == 0.0) ? "+0.0" : (deltaSign + valueAsString)
                 }
             }
             return ""

--- a/xDrip Widget/DataModels/XDripWidgetAttributes.swift
+++ b/xDrip Widget/DataModels/XDripWidgetAttributes.swift
@@ -133,9 +133,9 @@ struct XDripWidgetAttributes: ActivityAttributes {
                 // quickly check "value" and prevent "-0mg/dl" or "-0.0mmol/l" being displayed
                 // show unitized zero deltas as +0 or +0.0 as per Nightscout format
                 if (isMgDl) {
-                    return (deltaChangeInMgDl > -1 && deltaChangeInMgDl < 1) ?  "+0" : (deltaSign + valueAsString)
+                    return (deltaChangeInMgDl == 0) ?  "+0" : (deltaSign + valueAsString)
                 } else {
-                    return (deltaChangeInMgDl > -0.1 && deltaChangeInMgDl < 0.1) ? "+0.0" : (deltaSign + valueAsString)
+                    return (deltaChangeInMgDl == 0.0) ? "+0.0" : (deltaSign + valueAsString)
                 }
             } else {
                 return isMgDl ? "-" : "-.-"

--- a/xDrip Widget/XDripWidget+Entry.swift
+++ b/xDrip Widget/XDripWidget+Entry.swift
@@ -128,9 +128,9 @@ extension XDripWidget.Entry {
                 // quickly check "value" and prevent "-0mg/dl" or "-0.0mmol/l" being displayed
                 // show unitized zero deltas as +0 or +0.0 as per Nightscout format
                 if (isMgDl) {
-                    return (deltaChangeInMgDl > -1 && deltaChangeInMgDl < 1) ?  "+0" : (deltaSign + valueAsString)
+                    return (deltaChangeInMgDl == 0) ?  "+0" : (deltaSign + valueAsString)
                 } else {
-                    return (deltaChangeInMgDl > -0.1 && deltaChangeInMgDl < 0.1) ? "+0.0" : (deltaSign + valueAsString)
+                    return (deltaChangeInMgDl == 0.0) ? "+0.0" : (deltaSign + valueAsString)
                 }
             } else {
                 return isMgDl ? "-" : "-.-"

--- a/xdrip/Core Data/classes/BgReading+CoreDataClass.swift
+++ b/xdrip/Core Data/classes/BgReading+CoreDataClass.swift
@@ -181,13 +181,13 @@ public class BgReading: NSManagedObject {
         // quickly check "value" and prevent "-0mg/dl" or "-0.0mmol/l" being displayed
         // show unitized zero deltas as +0 or +0.0 as per Nightscout format
         if (mgdl) {
-            if (value > -1) && (value < 1) {
+            if (value == 0) {
                 return "+0" + (showUnit ? (" " + Texts_Common.mgdl):"");
             } else {
                 return deltaSign + valueAsString + (showUnit ? (" " + Texts_Common.mgdl):"");
             }
         } else {
-            if (value > -0.1) && (value < 0.1) {
+            if (value == 0.0) {
                 return "+0.0" + (showUnit ? (" " + Texts_Common.mmol):"");
             } else {
                 return deltaSign + valueAsString + (showUnit ? (" " + Texts_Common.mmol):"");


### PR DESCRIPTION
- BUG FIX: xDrip incorrectly reported +0 (or 0.0 for mmol) BG when delta was not 0 (or 0.0 for mmol) - this only occurred occasionally when BG deltas were around 1
- This fixes this issue, tested and verified on live device for mgdl