### PR TITLE
Colorize all BG text in iPhone widgets

### DIFF
--- a/xDrip Widget/Views/SystemLargeView.swift
+++ b/xDrip Widget/Views/SystemLargeView.swift
@@ -25,11 +25,11 @@ extension XDripWidget.EntryView {
                 HStack(alignment: .firstTextBaseline, spacing: 4) {
                     Text(entry.widgetState.deltaChangeStringInUserChosenUnit())
                         .font(.title).fontWeight(.semibold)
-                        .foregroundStyle(entry.widgetState.deltaChangeTextColor())
+                        .foregroundStyle(entry.widgetState.bgTextColor())
                         .lineLimit(1)
                     Text(entry.widgetState.bgUnitString)
                         .font(.title)
-                        .foregroundStyle(.colorTertiary)
+                        .foregroundStyle(entry.widgetState.bgTextColor())
                         .lineLimit(1)
                 }
             }

--- a/xDrip Widget/Views/SystemMediumView.swift
+++ b/xDrip Widget/Views/SystemMediumView.swift
@@ -25,11 +25,11 @@ extension XDripWidget.EntryView {
                 HStack(alignment: .firstTextBaseline, spacing: 4) {
                     Text(entry.widgetState.deltaChangeStringInUserChosenUnit())
                         .font(.title2).fontWeight(.semibold)
-                        .foregroundStyle(entry.widgetState.deltaChangeTextColor())
+                        .foregroundStyle(entry.widgetState.bgTextColor())
                         .lineLimit(1)
                     Text(entry.widgetState.bgUnitString)
                         .font(.title2)
-                        .foregroundStyle(.colorTertiary)
+                        .foregroundStyle(entry.widgetState.bgTextColor())
                         .lineLimit(1)
                 }
             }

--- a/xDrip Widget/Views/SystemSmallView.swift
+++ b/xDrip Widget/Views/SystemSmallView.swift
@@ -23,7 +23,7 @@ extension XDripWidget.EntryView {
                 
                 Text(entry.widgetState.deltaChangeStringInUserChosenUnit())
                     .font(.title).fontWeight(.semibold)
-                    .foregroundStyle(entry.widgetState.deltaChangeTextColor())
+                    .foregroundStyle(entry.widgetState.bgTextColor())
                     .minimumScaleFactor(0.5)
                     .lineLimit(1)
             }


### PR DESCRIPTION
- Color the delta and units in iPhone widgets
- To match BG/trend arrow